### PR TITLE
feat: Remove sensitivity setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,6 @@ the room they're located in. Please verify the list matches your expectations.
 * Renderer - Select which rendering engine to use, YafaRay or SunFlow
 * Image format - The image file format of the resulting floor plan (PNG or JPEG)
 * Quality - Choose the rendering quality (low or high)
-* Sensitivity - [1, 100] The degree by which two pixels need to be different
-  from one another to be taken into account for the generated overlay image.
-  Only relevant for "room overlay" light mixing mode and RGB lights
 * Output directory - The location on your PC where the floor plan images and
   YAML will be saved
 
@@ -231,7 +228,7 @@ When using the "Room overlay" light mixing mode, it's also suggested to:
   images with the transparent background.
 
   The renders directory was created (back when room overlay was the only option)
-  in case one wanted to change any parameters (like the sensitivity) to generate a
+  in case one wanted to change any parameters to generate a
   new floor plan without needing to wait for all the renders from SH3D, which
   don't change. It's basically a cache of rendered images.
 

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/ApplicationPlugin.properties
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/ApplicationPlugin.properties
@@ -29,7 +29,6 @@ HomeAssistantFloorPlan.Panel.lightMixingModeLabel.tooltip=<html>Choose method fo
 HomeAssistantFloorPlan.Panel.lightMixingModeComboBox.CSS.text=CSS
 HomeAssistantFloorPlan.Panel.lightMixingModeComboBox.OVERLAY.text=Room overlay
 HomeAssistantFloorPlan.Panel.lightMixingModeComboBox.FULL.text=Complete renders
-HomeAssistantFloorPlan.Panel.sensitivityLabel.text=Sensitivity:
 
 HomeAssistantFloorPlan.Panel.rendererLabel.text=Renderer:
 HomeAssistantFloorPlan.Panel.rendererComboBox.SUNFLOW.text=SunFlow

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -60,7 +60,6 @@ public class Controller {
     private static final String CONTROLLER_RENDER_WIDTH = "renderWidth";
     private static final String CONTROLLER_RENDER_HEIGHT = "renderHeigh";
     private static final String CONTROLLER_LIGHT_MIXING_MODE = "lightMixingMode";
-    private static final String CONTROLLER_SENSITIVTY = "sensitivity";
     private static final String CONTROLLER_RENDERER = "renderer";
     private static final String CONTROLLER_QUALITY = "quality";
     private static final String CONTROLLER_IMAGE_FORMAT = "imageFormat";
@@ -87,7 +86,6 @@ public class Controller {
     private int renderWidth;
     private int renderHeight;
     private LightMixingMode lightMixingMode;
-    private int sensitivity;
     private Renderer renderer;
     private Quality quality;
     private ImageFormat imageFormat;
@@ -120,7 +118,6 @@ public class Controller {
         renderWidth = settings.getInteger(CONTROLLER_RENDER_WIDTH, 1024);
         renderHeight = settings.getInteger(CONTROLLER_RENDER_HEIGHT, 576);
         lightMixingMode = LightMixingMode.valueOf(settings.get(CONTROLLER_LIGHT_MIXING_MODE, LightMixingMode.CSS.name()));
-        sensitivity = settings.getInteger(CONTROLLER_SENSITIVTY, 10);
         renderer = Renderer.valueOf(settings.get(CONTROLLER_RENDERER, Renderer.YAFARAY.name()));
         quality = Quality.valueOf(settings.get(CONTROLLER_QUALITY, Quality.HIGH.name()));
         imageFormat = ImageFormat.valueOf(settings.get(CONTROLLER_IMAGE_FORMAT, ImageFormat.PNG.name()));
@@ -199,15 +196,6 @@ public class Controller {
         this.renderWidth = renderWidth;
         settings.setInteger(CONTROLLER_RENDER_WIDTH, renderWidth);
         repositionEntities();
-    }
-
-    public int getSensitivity() {
-        return sensitivity;
-    }
-
-    public void setSensitivity(int sensitivity) {
-        this.sensitivity = sensitivity;
-        settings.setInteger(CONTROLLER_SENSITIVTY, sensitivity);
     }
 
     public LightMixingMode getLightMixingMode() {
@@ -907,11 +895,7 @@ private Rectangle findCropAreaFromStamp(BufferedImage stamp) {
                 if (((basePixel >> 24) & 0xff) == 0) {
                     continue;
                 }
-
-                int diff = pixelDifference(basePixel, image.getRGB(x, y));
-                if (diff > sensitivity) {
-                    overlay.setRGB(x, y, image.getRGB(x, y) | 0xFF000000);
-                }
+                overlay.setRGB(x, y, image.getRGB(x, y) | 0xFF000000);
             }
         }
         return overlay;
@@ -920,14 +904,6 @@ private Rectangle findCropAreaFromStamp(BufferedImage stamp) {
     private void saveFloorPlanImage(BufferedImage image, String name, String extension) throws IOException {
         File floorPlanFile = new File(outputFloorplanDirectoryName + File.separator + name + "." + extension);
         ImageIO.write(image, extension, floorPlanFile);
-    }
-
-    private int pixelDifference(int first, int second) {
-        int diff =
-            Math.abs((first & 0xff) - (second & 0xff)) +
-            Math.abs(((first >> 8) & 0xff) - ((second >> 8) & 0xff)) +
-            Math.abs(((first >> 16) & 0xff) - ((second >> 16) & 0xff));
-        return diff / 3;
     }
 
     private BufferedImage generateRedTintedImage(BufferedImage image, String imageName) throws IOException {

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Panel.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Panel.java
@@ -92,8 +92,6 @@ public class Panel extends JPanel implements DialogView {
     private JSpinner heightSpinner;
     private JLabel lightMixingModeLabel;
     private JComboBox<Controller.LightMixingMode> lightMixingModeComboBox;
-    private JLabel sensitivityLabel;
-    private JSpinner sensitivitySpinner;
     private JLabel rendererLabel;
     private JComboBox<Controller.Renderer> rendererComboBox;
     private JLabel qualityLabel;
@@ -347,17 +345,6 @@ public class Panel extends JPanel implements DialogView {
             }
         });
 
-        sensitivityLabel = new JLabel();
-        sensitivityLabel.setText(resource.getString("HomeAssistantFloorPlan.Panel.sensitivityLabel.text"));
-        final SpinnerNumberModel sensitivitySpinnerModel = new SpinnerNumberModel(15, 0, 100, 1);
-        sensitivitySpinner = new AutoCommitSpinner(sensitivitySpinnerModel);
-        sensitivitySpinnerModel.setValue(controller.getSensitivity());
-        sensitivitySpinner.addChangeListener(new ChangeListener() {
-            public void stateChanged(ChangeEvent ev) {
-              controller.setSensitivity(((Number)sensitivitySpinner.getValue()).intValue());
-            }
-        });
-
         rendererLabel = new JLabel();
         rendererLabel.setText(resource.getString("HomeAssistantFloorPlan.Panel.rendererLabel.text"));
         rendererComboBox = new JComboBox<Controller.Renderer>(Controller.Renderer.values());
@@ -573,7 +560,6 @@ public class Panel extends JPanel implements DialogView {
         widthSpinner.setEnabled(enabled);
         heightSpinner.setEnabled(enabled);
         lightMixingModeComboBox.setEnabled(enabled);
-        sensitivitySpinner.setEnabled(enabled);
         rendererComboBox.setEnabled(enabled);
         qualityComboBox.setEnabled(enabled);
         renderTimeSpinner.setEnabled(enabled);
@@ -702,18 +688,11 @@ public class Panel extends JPanel implements DialogView {
             GridBagConstraints.HORIZONTAL, insets, 0, 0));
         currentGridYIndex++;
 
-        /* Sensitivity */
-        add(sensitivityLabel, new GridBagConstraints(
+        add(transparencyThresholdLabel, new GridBagConstraints(
             0, currentGridYIndex, 1, 1, 0, 0, GridBagConstraints.CENTER,
             GridBagConstraints.HORIZONTAL, insets, 0, 0));
-        add(sensitivitySpinner, new GridBagConstraints(
-            1, currentGridYIndex, 1, 1, 0, 0, GridBagConstraints.CENTER,
-            GridBagConstraints.HORIZONTAL, insets, 0, 0));
-        add(transparencyThresholdLabel, new GridBagConstraints(
-            2, currentGridYIndex, 1, 1, 0, 0, GridBagConstraints.CENTER,
-            GridBagConstraints.HORIZONTAL, insets, 0, 0));
         add(transparencyThresholdSpinner, new GridBagConstraints(
-            3, currentGridYIndex, 1, 1, 0, 0, GridBagConstraints.CENTER,
+            1, currentGridYIndex, 1, 1, 0, 0, GridBagConstraints.CENTER,
             GridBagConstraints.HORIZONTAL, insets, 0, 0));
         currentGridYIndex++;
 


### PR DESCRIPTION
Removes the "sensitivity" setting and its associated functionality entirely from the application.

This change includes:
- Removal of the sensitivity slider from the UI panel.
- Removal of the backend logic in the Controller that handled the sensitivity value.
- The `generateFloorPlanImage` method for the "Room overlay" mode now creates a full copy of the light-on image, as per user instruction, instead of a pixel-difference-based overlay.
- Removal of the corresponding documentation from the README file.

### Description

[Describe the changes made in this pull request]

### How Has This Been Tested?

[Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration]

### Checklist

* [ ] I have tested and built the changes locally and they work as expected
* [ ] I have added relevant documentation or updated existing documentation
* [ ] My changes generate no new warnings

### Screenshots (if applicable)

[Include any relevant screenshots or visual representations of the changes]

### Additional Context

[Provide any additional information or context related to this PR]
